### PR TITLE
Fix DataFrame append usage

### DIFF
--- a/app.py
+++ b/app.py
@@ -54,7 +54,9 @@ try:
                     "Status": "",
                     "Last Updated": pd.Timestamp.today().date(),
                 }
-                df = df.append(new_row, ignore_index=True)
+                # Append the new row using pandas concat to avoid the deprecated
+                # DataFrame.append method
+                df = pd.concat([df, pd.DataFrame([new_row])], ignore_index=True)
                 df.to_csv(csv_path, index=False)
                 st.session_state.creator_names.append(new_name)
                 st.experimental_rerun()


### PR DESCRIPTION
## Summary
- use `pd.concat` instead of removed `DataFrame.append`

## Testing
- `python -m py_compile app.py utils/*.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68645fd7cd5883318e82f8b05a7f69be