### PR TITLE
Fix news markdown formatting

### DIFF
--- a/app.py
+++ b/app.py
@@ -110,10 +110,10 @@ try:
         if news_results:
             for article in news_results:
                 st.markdown(
-                    f"""**{article['title']}**
-*{article['source']} - {article['publishedAt']}*
-{article['description']}
-[Read more]({article['url']})"""
+                    f"**{article['title']}**\n"
+                    f"*{article['source']} - {article['publishedAt']}*\n"
+                    f"{article['description']}\n"
+                    f"[Read more]({article['url']})"
                 )
         else:
             st.write("No recent news mentions found.")


### PR DESCRIPTION
## Summary
- avoid multiline f-string bug when showing news articles

## Testing
- `python -m py_compile app.py utils/*.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686465adfa248331866b6e6b722d6369