### PR TITLE
Fix KeyError in sentiment analysis

### DIFF
--- a/utils/sentiment_check.py
+++ b/utils/sentiment_check.py
@@ -22,9 +22,9 @@ def sentiment_summary(comments):
         }
 
     summary = {
-        "positive": round((count["positive"] / total) * 100, 1),
-        "neutral": round((count["neutral"] / total) * 100, 1),
-        "negative": round((count["negative"] / total) * 100, 1)
+        "positive": round((count.get("positive", 0) / total) * 100, 1),
+        "neutral": round((count.get("neutral", 0) / total) * 100, 1),
+        "negative": round((count.get("negative", 0) / total) * 100, 1)
     }
 
     explanations = {


### PR DESCRIPTION
## Summary
- handle missing sentiment categories in utils/sentiment_check.py

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68646a6d19408331bef16f98b05e1b6f