### PR TITLE
Fix sentiment and news search

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A Streamlit app for managing and monitoring a roster of YouTube creators. Tracks performance, requests, news mentions, and sentiment analysis.
 
+Recent updates ensure that the most recent video comments are pulled (using the time-ordered comment API) so sentiment analysis works again. News alerts now search by both a creator's name and channel title for more relevant results.
+
 ## Getting Started
 
 1. Install the required packages:

--- a/app.py
+++ b/app.py
@@ -4,7 +4,12 @@ import pandas as pd
 import os
 from utils.news_alerts import fetch_news_mentions
 from utils.sentiment_check import sentiment_summary
-from utils.youtube_api import get_latest_video_id, get_comments, get_channel_stats
+from utils.youtube_api import (
+    get_latest_video_id,
+    get_comments,
+    get_channel_stats,
+    get_channel_title,
+)
 
 st.set_page_config(page_title="Creator Intelligence Dashboard", layout="wide")
 st.title("🎬 YouTube Creator Intelligence Dashboard")
@@ -65,7 +70,8 @@ if not df.empty:
 
     # News Mentions
     st.subheader("📰 News Mentions")
-    news_results = fetch_news_mentions(selected_creator, api_key_news)
+    channel_name = get_channel_title(channel_id, api_key_yt) or selected_creator
+    news_results = fetch_news_mentions(selected_creator, channel_name, api_key_news)
     if news_results:
         for article in news_results:
             st.markdown(

--- a/utils/news_alerts.py
+++ b/utils/news_alerts.py
@@ -1,7 +1,9 @@
 import requests
+from urllib.parse import quote_plus
 
-def fetch_news_mentions(creator_name, api_key):
-    url = f"https://gnews.io/api/v4/search?q=\"{creator_name}\"&lang=en&max=10&token={api_key}"
+def fetch_news_mentions(creator_name, channel_name, api_key):
+    query = f'"{creator_name}" OR "{channel_name}"'
+    url = f"https://gnews.io/api/v4/search?q={quote_plus(query)}&lang=en&max=10&token={api_key}"
     response = requests.get(url)
     if response.status_code == 200:
         articles = response.json().get("articles", [])

--- a/utils/youtube_api.py
+++ b/utils/youtube_api.py
@@ -19,7 +19,7 @@ def get_latest_video_id(channel_id, api_key):
     """
     url = (
         f"https://www.googleapis.com/youtube/v3/search"
-        f"?key={api_key}&channelId={channel_id}&part=snippet,id&order=date&maxResults=1"
+        f"?key={api_key}&channelId={channel_id}&part=snippet,id&order=date&type=video&maxResults=1"
     )
     response = requests.get(url).json()
     try:
@@ -34,7 +34,7 @@ def get_comments(video_id, api_key, max_results=100):
     comments = []
     url = (
         f"https://www.googleapis.com/youtube/v3/commentThreads"
-        f"?key={api_key}&textFormat=plainText&part=snippet&videoId={video_id}&maxResults={max_results}"
+        f"?key={api_key}&textFormat=plainText&part=snippet&videoId={video_id}&maxResults={max_results}&order=time"
     )
     response = requests.get(url).json()
     try:
@@ -44,3 +44,34 @@ def get_comments(video_id, api_key, max_results=100):
     except Exception:
         pass
     return comments
+
+
+def get_channel_stats(channel_id, api_key):
+    """Return subscriber, view, and video counts for a channel."""
+    url = (
+        "https://www.googleapis.com/youtube/v3/channels"
+        f"?key={api_key}&id={channel_id}&part=statistics"
+    )
+    data = requests.get(url).json()
+    try:
+        stats = data["items"][0]["statistics"]
+        return {
+            "subscribers": stats.get("subscriberCount"),
+            "views": stats.get("viewCount"),
+            "videos": stats.get("videoCount"),
+        }
+    except (KeyError, IndexError):
+        return None
+
+
+def get_channel_title(channel_id, api_key):
+    """Fetch the public title of a channel."""
+    url = (
+        "https://www.googleapis.com/youtube/v3/channels"
+        f"?key={api_key}&id={channel_id}&part=snippet"
+    )
+    data = requests.get(url).json()
+    try:
+        return data["items"][0]["snippet"]["title"]
+    except (KeyError, IndexError):
+        return None


### PR DESCRIPTION
## Summary
- ensure search API only returns videos
- add helpers to get channel stats and title
- search news using creator and channel name
- wire up new functions in app
- document latest changes
- use time-ordered comments for sentiment analysis

## Testing
- `python -m py_compile utils/*.py app.py`


------
https://chatgpt.com/codex/tasks/task_e_6864787e105c833181fa327e1a68e2bd