### PR TITLE
Fix comment pagination and sentiment examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Streamlit app for managing and monitoring a roster of YouTube creators. Tracks performance, requests, news mentions, and sentiment analysis.
 
-Recent updates ensure that the latest video comments are properly retrieved for sentiment analysis and that news alerts search by both a creator's name and their channel title for more relevant results.
+Recent updates improve comment retrieval to capture more comments from a creator's newest video for sentiment analysis and ensure news alerts search by both a creator's name and their channel title for more relevant results.
 
 ## Getting Started
 

--- a/utils/sentiment_check.py
+++ b/utils/sentiment_check.py
@@ -12,7 +12,9 @@ def analyze_sentiment(text):
         return "neutral"
 
 def sentiment_summary(comments):
-    results = [analyze_sentiment(comment) for comment in comments]
+    """Return sentiment percentages and example comments."""
+    labeled = [(c, analyze_sentiment(c)) for c in comments]
+    results = [label for _, label in labeled]
     total = len(results)
     count = Counter(results)
     if total == 0:
@@ -24,12 +26,12 @@ def sentiment_summary(comments):
     summary = {
         "positive": round((count.get("positive", 0) / total) * 100, 1),
         "neutral": round((count.get("neutral", 0) / total) * 100, 1),
-        "negative": round((count.get("negative", 0) / total) * 100, 1)
+        "negative": round((count.get("negative", 0) / total) * 100, 1),
     }
 
     explanations = {
-        "positive": [c for c in comments if analyze_sentiment(c) == "positive"][:3],
-        "negative": [c for c in comments if analyze_sentiment(c) == "negative"][:3]
+        "positive": [c for c, label in labeled if label == "positive"][:3],
+        "negative": [c for c, label in labeled if label == "negative"][:3],
     }
 
     return summary, explanations

--- a/utils/youtube_api.py
+++ b/utils/youtube_api.py
@@ -28,21 +28,24 @@ def get_latest_video_id(channel_id, api_key):
         return None
 
 def get_comments(video_id, api_key, max_results=100):
-    """
-    Retrieves top-level comments from a video.
-    """
+    """Retrieve up to ``max_results`` top-level comments from a video."""
     comments = []
-    url = (
+    base_url = (
         f"https://www.googleapis.com/youtube/v3/commentThreads"
-        f"?key={api_key}&textFormat=plainText&part=snippet&videoId={video_id}&maxResults={max_results}"
+        f"?key={api_key}&textFormat=plainText&part=snippet&videoId={video_id}&maxResults=100"
     )
-    response = requests.get(url).json()
-    try:
-        for item in response.get("items", []):
+    page_token = ""
+    while len(comments) < max_results:
+        url = base_url + (f"&pageToken={page_token}" if page_token else "")
+        data = requests.get(url).json()
+        for item in data.get("items", []):
             comment = item["snippet"]["topLevelComment"]["snippet"]["textDisplay"]
             comments.append(comment)
-    except Exception:
-        pass
+            if len(comments) >= max_results:
+                break
+        page_token = data.get("nextPageToken")
+        if not page_token:
+            break
     return comments
 
 


### PR DESCRIPTION
## Summary
- fetch comments across pages so we don't miss any
- reuse analyzed sentiments when building examples
- mention the new behavior in the docs

## Testing
- `python -m py_compile app.py utils/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68647ba52dc883318f5d19eea2e3587b