### PR TITLE
Store api key in app secrets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,6 @@ ENV/
 # Miscellaneous
 .DS_Store
 Thumbs.db
+
+# Streamlit secrets
+.streamlit/secrets.toml


### PR DESCRIPTION
Add `.streamlit/secrets.toml` to `.gitignore` to prevent sensitive API keys from being committed.

---

[Open in Web](https://www.cursor.com/agents?id=bc-0adc4ed4-e9f5-4975-8ea2-6ad231dc179a) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-0adc4ed4-e9f5-4975-8ea2-6ad231dc179a)